### PR TITLE
chore: repoint hardcoded paths from Documents/dev_and_debug to ~/src

### DIFF
--- a/ai/gemini_settings.json
+++ b/ai/gemini_settings.json
@@ -7,9 +7,9 @@
   },
   "mcpServers": {
     "nuon": {
-      "command": "/Users/markmilligan/documents/dev_and_debug/src/mark/nuon-mcp/venv/bin/python",
+      "command": "/Users/markmilligan/src/mark/nuon-mcp/venv/bin/python",
       "args": [
-        "/Users/markmilligan/documents/dev_and_debug/src/mark/nuon-mcp/server.py"
+        "/Users/markmilligan/src/mark/nuon-mcp/server.py"
       ],
       "env": {}
     }

--- a/install.sh
+++ b/install.sh
@@ -853,7 +853,7 @@ REPO_CURRENT_FRESH_CLONE=false
 # Hardcoded default scan path. Stored as a literal string with $HOME so
 # git_pull_all.sh expands it at read time. Edit directories.txt after the
 # first run if your dev tree lives somewhere else on a given Mac.
-REPO_CURRENT_PREFERRED_PATH='$HOME/Documents/dev_and_debug/src'
+REPO_CURRENT_PREFERRED_PATH='$HOME/src'
 
 if [ ! -d "$REPO_CURRENT_DIR" ]; then
     if [ "$DRY_RUN" = true ]; then

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -79,7 +79,7 @@ require("lazy").setup({
         local v = tonumber(f:read("*l")); f:close()
         if v == 1 then
           local fork_path = vim.fn.expand(
-            os.getenv("AVANTE_FORK_PATH") or "~/Documents/dev_and_debug/src/mark/avante.nvim"
+            os.getenv("AVANTE_FORK_PATH") or "~/src/mark/avante.nvim"
           )
           if vim.fn.isdirectory(fork_path) == 1 then
             vim.g.avante_fork_loaded = "jon"
@@ -149,7 +149,7 @@ require("lazy").setup({
         -- Guard: if jon's fork is selected but directory not present, warn and skip
         if cfg.fork == "jon" then
           local fork_path = vim.fn.expand(
-            os.getenv("AVANTE_FORK_PATH") or "~/Documents/dev_and_debug/src/mark/avante.nvim"
+            os.getenv("AVANTE_FORK_PATH") or "~/src/mark/avante.nvim"
           )
           if vim.fn.isdirectory(fork_path) ~= 1 then
             vim.notify("Jon's avante fork not found at " .. fork_path .. ".\nClone: https://github.com/jonmorehouse/avante.nvim\nOr set AVANTE_FORK_PATH env var.", vim.log.levels.ERROR)
@@ -195,7 +195,7 @@ require("lazy").setup({
       -- To add a new provider, add an entry to provider_configs in config above.
       -- ====================================================
 
-      shortcuts_directory = vim.fn.expand("~/Documents/dev_and_debug/src/mark/avante-shortcuts"),
+      shortcuts_directory = vim.fn.expand("~/src/mark/avante-shortcuts"),
 
       -- ACP provider configuration for Claude Code
       -- This section is only used when provider = "claude-code"


### PR DESCRIPTION
Repos are moving out of ~/Documents/dev_and_debug/src to ~/src (dropping the dev_and_debug wrapper). Update the dotfiles that hardcode the old location: install.sh repo-current scan path, nvim avante fork/shortcuts paths, gemini nuon-mcp server path (also fixes lowercase documents typo), and the brew.sh permission entry.